### PR TITLE
Touchup example config and docs syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The certificate is located here:
 Example configuration looks like this:
 
 ## nginx
-```
+```nginx
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
@@ -75,7 +75,7 @@ server {
 ```
 
 ## apache
-```
+```apache
 <VirtualHost *:443>
     SSLEngine on
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ systemctl enable --now acme-redirect-renew.timer
 
 The certificate is located here:
 ```
-/var/lib/acme-redirect/live/example.com/live/fullchain
-/var/lib/acme-redirect/live/example.com/live/privkey
+/var/lib/acme-redirect/live/example.com/fullchain
+/var/lib/acme-redirect/live/example.com/privkey
 ```
 
 Example configuration looks like this:
@@ -53,8 +53,8 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    ssl_certificate /var/lib/acme-redirect/live/EXAMPLE.COM/live/fullchain;
-    ssl_certificate_key /var/lib/acme-redirect/live/EXAMPLE.COM/live/privkey;
+    ssl_certificate /var/lib/acme-redirect/live/example.com/fullchain;
+    ssl_certificate_key /var/lib/acme-redirect/live/example.com/privkey;
     ssl_session_timeout 1d;
     ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
     ssl_session_tickets off;
@@ -67,7 +67,7 @@ server {
 
     ssl_stapling on;
     ssl_stapling_verify on;
-    ssl_trusted_certificate /var/lib/acme-redirect/live/EXAMPLE.COM/chain;
+    ssl_trusted_certificate /var/lib/acme-redirect/live/example.com/chain;
     resolver 127.0.0.1;
 
     # ...
@@ -79,8 +79,8 @@ server {
 <VirtualHost *:443>
     SSLEngine on
 
-    SSLCertificateFile /var/lib/acme-redirect/live/EXAMPLE.COM/live/fullchain
-    SSLCertificateKeyFile /var/lib/acme-redirect/live/EXAMPLE.COM/live/privkey
+    SSLCertificateFile /var/lib/acme-redirect/live/example.com/fullchain
+    SSLCertificateKeyFile /var/lib/acme-redirect/live/example.com/privkey
 
     Protocols h2 http/1.1
     Header always set Strict-Transport-Security "max-age=63072000"
@@ -100,10 +100,10 @@ SSLStaplingCache "shmcb:logs/ssl_stapling(32768)"
 server.modules += ("mod_openssl")
 $SERVER["socket"] == "0.0.0.0:443" {
     ssl.engine = "enable"
-    ssl.privkey= "/var/lib/acme-redirect/live/EXAMPLE.COM/live/privkey"
-    ssl.pemfile= "/var/lib/acme-redirect/live/EXAMPLE.COM/live/fullchain"
+    ssl.privkey= "/var/lib/acme-redirect/live/example.com/privkey"
+    ssl.pemfile= "/var/lib/acme-redirect/live/example.com/fullchain"
     ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.2")
-    #ssl.ca-file= "/var/lib/acme-redirect/live/EXAMPLE.COM/chain" # (needed in $SERVER["socket"] before lighttpd 1.4.56 if ssl.pemfile in $HTTP["host"])
+    #ssl.ca-file= "/var/lib/acme-redirect/live/example.com/chain" # (needed in $SERVER["socket"] before lighttpd 1.4.56 if ssl.pemfile in $HTTP["host"])
 }
 ```
 

--- a/contrib/confs/acme-redirect.conf
+++ b/contrib/confs/acme-redirect.conf
@@ -1,3 +1,4 @@
 [acme]
 #acme_email = "nobody@example.com"
 #acme_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
+#renew_if_days_left = 30

--- a/contrib/confs/acme-redirect.conf
+++ b/contrib/confs/acme-redirect.conf
@@ -1,3 +1,3 @@
 [acme]
-#acme_email = "nobody@example.com
+#acme_email = "nobody@example.com"
 #acme_url = "https://acme-staging-v02.api.letsencrypt.org/directory"

--- a/contrib/docs/acme-redirect.conf.5.scd
+++ b/contrib/docs/acme-redirect.conf.5.scd
@@ -31,7 +31,7 @@ _renew_if_days_left=_
 
 ```
 [acme]
-acme_email = "nobody@example.com
+acme_email = "nobody@example.com"
 acme_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
 ```
 

--- a/contrib/docs/acme-redirect.conf.5.scd
+++ b/contrib/docs/acme-redirect.conf.5.scd
@@ -33,6 +33,7 @@ _renew_if_days_left=_
 [acme]
 acme_email = "nobody@example.com"
 acme_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
+renew_if_days_left = 30
 ```
 
 # SEE ALSO


### PR DESCRIPTION
- Fix syntax typo in example configs
- Add missing language callouts to Markdown fenced code blocks
