### PR TITLE
Introduce global `exec=` and `exec_extra=`

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -12,13 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install cargo-deb
-      run: cargo install cargo-deb
-
     - uses: actions/checkout@v2
 
     - name: Build package
-      run: cargo deb
+      run: contrib/debian/build.sh
 
     - name: Rename package
       run: mv target/debian/acme-redirect*.deb acme-redirect.deb

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,21 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+    - name: Push to GitHub Packages
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
+        repository: kpcyrd/acme-redirect/acme-redirect
+        tag_with_ref: true

--- a/contrib/confs/acme-redirect.conf
+++ b/contrib/confs/acme-redirect.conf
@@ -2,3 +2,13 @@
 #acme_email = "nobody@example.com"
 #acme_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
 #renew_if_days_left = 30
+
+[system]
+## Default hooks of the certificate config doesn't define any
+#exec = [
+#    "systemctl reload nginx"
+#]
+## Execute these hooks globally for all certificates
+#exec_extra = [
+#    "systemctl reload nginx"
+#]

--- a/contrib/debian/Dockerfile
+++ b/contrib/debian/Dockerfile
@@ -1,0 +1,3 @@
+FROM rust
+RUN apt-get update && apt-get install -y build-essential pkg-config libssl-dev
+RUN cargo install cargo-deb

--- a/contrib/debian/build.sh
+++ b/contrib/debian/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+docker build -t pkg-debian-acme-redirect-build contrib/debian/
+docker run --rm \
+    -v "$PWD:/src" \
+    -w /src \
+    pkg-debian-acme-redirect-build \
+    cargo deb
+docker run --rm \
+    -v "$PWD:/src" \
+    pkg-debian-acme-redirect-build \
+    chown -vR "$(id -u):$(id -g)" /src/target

--- a/contrib/docs/acme-redirect.conf.5.scd
+++ b/contrib/docs/acme-redirect.conf.5.scd
@@ -13,7 +13,7 @@ acme-redirect.conf - *acme-redirect* configuration files
 This file configures general settings for *acme-redirect*. To configure
 certificates have a look at *acme-redirect.d*(5).
 
-# OPTIONS
+# OPTIONS ([acme])
 
 _acme_email=_
 	The contact email for your acme provider to reach out to you. They are
@@ -27,6 +27,17 @@ _renew_if_days_left=_
 	Renew the certificate if the number of days is *equal or lower*. You are
 	going to run into issues if you set it lower than 1. The default is 30.
 
+# OPTIONS ([system])
+
+_exec=_
+	A list of global fallback hooks that are executed if the certificate
+	config didn't specify any hooks. The hooks are expected to be shell
+	commands.
+
+_exec_extra=_
+	A list of global hooks that are executed after any certificate is renewed and
+	its hooks have been executed. The hooks are expected to be shell commands.
+
 # EXAMPLE
 
 ```
@@ -34,6 +45,16 @@ _renew_if_days_left=_
 acme_email = "nobody@example.com"
 acme_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
 renew_if_days_left = 30
+
+[system]
+## Default hooks if the certificate config doesn't define any
+exec = [
+    "systemctl reload nginx",
+]
+## Execute these hooks globally for all certificates
+exec_extra = [
+    "systemctl reload dovecot",
+]
 ```
 
 # SEE ALSO

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub const DEFAULT_RENEW_IF_DAYS_LEFT: i64 = 30;
 pub struct ConfigFile {
     #[serde(default)]
     pub acme: AcmeConfig,
+    #[serde(default)]
+    pub system: SystemConfig,
 }
 
 #[derive(Debug, Default, PartialEq, Deserialize)]
@@ -21,6 +23,14 @@ pub struct AcmeConfig {
     pub acme_email: Option<String>,
     pub acme_url: Option<String>,
     pub renew_if_days_left: Option<i64>,
+}
+
+#[derive(Debug, Default, PartialEq, Deserialize)]
+pub struct SystemConfig {
+    #[serde(default)]
+    pub exec: Vec<String>,
+    #[serde(default)]
+    pub exec_extra: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Deserialize)]
@@ -76,6 +86,8 @@ pub struct Config {
     pub renew_if_days_left: i64,
     pub data_dir: PathBuf,
     pub chall_dir: PathBuf,
+    pub exec: Vec<String>,
+    pub exec_extra: Vec<String>,
 }
 
 impl Config {
@@ -113,6 +125,8 @@ pub fn load(args: &Args) -> Result<Config> {
         data_dir: PathBuf::from(&args.data_dir),
         chall_dir: PathBuf::from(&args.chall_dir),
         certs,
+        exec: config.system.exec,
+        exec_extra: config.system.exec_extra,
     })
 }
 


### PR DESCRIPTION
Extracted from #16, introduces just the `[system]` config section, global `exec=` and global `exec_extra=`.

Resolves #9.