### PR TITLE
add an option to check before renewal

### DIFF
--- a/contrib/systemd/acme-redirect-renew.service
+++ b/contrib/systemd/acme-redirect-renew.service
@@ -2,4 +2,4 @@
 Description=acme-redirect: renew certs if necessary
 
 [Service]
-ExecStart=/usr/bin/acme-redirect renew
+ExecStart=/usr/bin/acme-redirect renew --check-first

--- a/src/args.rs
+++ b/src/args.rs
@@ -79,6 +79,9 @@ pub struct RenewArgs {
     /// Do not actually do anything, just show what would happen
     #[arg(short = 'n', long)]
     pub dry_run: bool,
+    /// check before requesting renewal or creation of a certificate
+    #[arg(long)]
+    pub check_first: bool,
     /// Renew certificates even if they are not about to expire
     #[arg(long)]
     pub force_renew: bool,

--- a/src/check.rs
+++ b/src/check.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub fn check(name: &str, token: &str) -> Result<()> {
+pub fn check(name: &str, config: &Config) -> Result<()> {
+    let mut chall = Challenge::new(&config);
+    let token = chall.random()?;
     let url = format!("http://{name}/.well-known/acme-challenge/{token}");
     let r = ureq::get(&url).timeout(REQUEST_TIMEOUT).call()?;
 
@@ -24,17 +26,16 @@ pub fn check(name: &str, token: &str) -> Result<()> {
         bail!("response body didn't match expected token");
     }
 
+    chall.cleanup()?;
+
     Ok(())
 }
 
 pub fn run(config: Config, mut args: CheckArgs) -> Result<()> {
-    let mut chall = Challenge::new(&config);
-    let token = chall.random()?;
-
     let filter = args.certs.drain(..).collect::<HashSet<_>>();
     for cert in config.filter_certs(&filter) {
         for dns_name in &cert.dns_names {
-            if let Err(err) = check(dns_name, &token) {
+            if let Err(err) = check(dns_name, &config) {
                 error!(
                     "Check failed ({:?} -> {:?}): {:#}",
                     cert.name, dns_name, err
@@ -44,8 +45,6 @@ pub fn run(config: Config, mut args: CheckArgs) -> Result<()> {
             }
         }
     }
-
-    chall.cleanup()?;
 
     Ok(())
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub fn check(name: &str, config: &Config) -> Result<()> {
-    let mut chall = Challenge::new(&config);
+    let mut chall = Challenge::new(config);
     let token = chall.random()?;
     let url = format!("http://{name}/.well-known/acme-challenge/{token}");
     let r = ureq::get(&url).timeout(REQUEST_TIMEOUT).call()?;

--- a/src/renew.rs
+++ b/src/renew.rs
@@ -74,7 +74,7 @@ fn renew_cert(
         if args.check_first {
             info!("checking before renewal {:?}", cert.name);
             check::check(&cert.name, config).with_context(|| {
-                anyhow!("checking of domain prior to renewal failed {:?}", cert.name)
+                anyhow!("checking of domain prior to renewal failed {:?}", cert.name);
             })?
         }
 

--- a/src/renew.rs
+++ b/src/renew.rs
@@ -73,7 +73,7 @@ fn renew_cert(
     } else {
         if args.check_first {
             info!("checking before renewal {:?}", cert.name);
-            check::check(&cert.name, &config).with_context(|| {
+            check::check(&cert.name, config).with_context(|| {
                 anyhow!("checking of domain prior to renewal failed {:?}", cert.name)
             })?
         }

--- a/src/renew.rs
+++ b/src/renew.rs
@@ -73,9 +73,7 @@ fn renew_cert(
     } else {
         if args.check_first {
             info!("checking before renewal {:?}", cert.name);
-            check::check(&cert.name, config).with_context(|| {
-                anyhow!("checking of domain prior to renewal failed {:?}", cert.name);
-            })?
+            check::check(&cert.name, config).with_context(|| anyhow!("checking of domain prior to renewal failed {:?}", cert.name))?
         }
 
         info!("renewing {:?}", cert.name);

--- a/src/renew.rs
+++ b/src/renew.rs
@@ -73,7 +73,7 @@ fn renew_cert(
     } else {
         if args.check_first {
             info!("checking before renewal {:?}", cert.name);
-            check::check(&cert.name, config).with_context(|| anyhow!("checking of domain prior to renewal failed {:?}", cert.name))?
+            check::check(&cert.name, config).with_context(|| anyhow!("checking of domain prior to renewal failed {:?}", cert.name))?;
         }
 
         info!("renewing {:?}", cert.name);

--- a/src/renew.rs
+++ b/src/renew.rs
@@ -1,6 +1,7 @@
 use crate::acme;
 use crate::args::RenewArgs;
 use crate::chall::Challenge;
+use crate::check;
 use crate::config::CertConfig;
 use crate::config::Config;
 use crate::errors::*;
@@ -70,6 +71,13 @@ fn renew_cert(
     if args.dry_run || args.hooks_only {
         info!("renewing {:?} (dry run)", cert.name);
     } else {
+        if args.check_first {
+            info!("checking before renewal {:?}", cert.name);
+            check::check(&cert.name, &config).with_context(|| {
+                anyhow!("checking of domain prior to renewal failed {:?}", cert.name)
+            })?
+        }
+
         info!("renewing {:?}", cert.name);
         acme::request(
             persist.clone(),


### PR DESCRIPTION
Hey,

if you have a server with many certificates, some of them might get stale & in order not to spam letsencrypt with invalid requests it'd be cool if the service atleast doesn't try to do invalid requests all the time.