### PR TITLE
Add landlock integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "colored",
  "config",
  "env_logger",
+ "landlock",
  "log",
  "nix 0.31.3",
  "pem",
@@ -741,6 +742,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1250,17 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ x509-parser = "0.18"
 
 [target.'cfg(target_os="linux")'.dependencies]
 caps = "0.5"
+landlock = "0.4"
 
 [dev-dependencies]
 boxxy = "0.14"

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -39,6 +39,35 @@ fn drop_caps() -> Result<()> {
     Ok(())
 }
 
+fn landlock() -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        use landlock::{
+            Access, AccessFs, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus,
+            path_beneath_rules,
+        };
+
+        let path = env::current_dir().context("Failed to determine current directory")?;
+
+        let abi = landlock::ABI::V1;
+        let status = Ruleset::default()
+            .handle_access(AccessFs::from_all(abi))?
+            .create()?
+            .add_rules(path_beneath_rules(&[path], AccessFs::from_read(abi)))?
+            .restrict_self()?;
+
+        match status.ruleset {
+            RulesetStatus::FullyEnforced => info!("Successfully enabled landlock rules"),
+            RulesetStatus::PartiallyEnforced => {
+                warn!("Partially enabled landlock rules, please update your kernel")
+            }
+            RulesetStatus::NotEnforced => bail!("Could not enforce, please update your kernel"),
+        }
+    }
+
+    Ok(())
+}
+
 pub fn init(args: &DaemonArgs) -> Result<()> {
     let user = if let Some(name) = &args.user {
         debug!("Resolving uid for {:?}", name);
@@ -68,6 +97,15 @@ pub fn init(args: &DaemonArgs) -> Result<()> {
     }
 
     drop_caps()?;
+
+    if let Err(err) = landlock() {
+        // This is intentionally not a fatal error, so you can run acme-redirect on kernels
+        // without landlock support.
+        // On most deployments, the same effect of having filesystem access restricted to a
+        // ready-only webroot (and nothing else) is already enforced through chroot and
+        // filesystem permissions.
+        warn!("Failed to set up landlock: {err:#}");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This adds a very simple rule restricting filesystem access to read-only access on the webroot, and nothing else.

In most deployment this is already given through chroot and filesystem permissions.